### PR TITLE
Add supplemental metadata tagging for ConnectionMetadataInjector

### DIFF
--- a/RandoPlus/Consts.cs
+++ b/RandoPlus/Consts.cs
@@ -1,11 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using ItemChanger;
-
-namespace RandoPlus
+﻿namespace RandoPlus
 {
     public static class Consts
     {
@@ -25,6 +18,9 @@ namespace RandoPlus
         public const string MrMushroomKingsPass = "Mr_Mushroom-King's_Pass";
 
         public const string MushPool = "MrMushroom";
+
+        public const string SkillsPoolGroup = "Skills";
+        public const string LoreTabletPoolGroup = "Lore Tablets";
 
         public const float LOGICPRIORITY = 50f;
     }

--- a/RandoPlus/Consts.cs
+++ b/RandoPlus/Consts.cs
@@ -1,4 +1,11 @@
-﻿namespace RandoPlus
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ItemChanger;
+
+namespace RandoPlus
 {
     public static class Consts
     {

--- a/RandoPlus/MrMushroom/ICInterop.cs
+++ b/RandoPlus/MrMushroom/ICInterop.cs
@@ -1,4 +1,8 @@
-﻿using ItemChanger;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using ItemChanger;
+using ItemChanger.Items;
 using ItemChanger.UIDefs;
 
 namespace RandoPlus.MrMushroom

--- a/RandoPlus/MrMushroom/ICInterop.cs
+++ b/RandoPlus/MrMushroom/ICInterop.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using ItemChanger;
-using ItemChanger.Items;
+﻿using ItemChanger;
 using ItemChanger.UIDefs;
 
 namespace RandoPlus.MrMushroom
@@ -11,7 +7,7 @@ namespace RandoPlus.MrMushroom
     {
         public static void DefineItemsAndLocations()
         {
-            Finder.DefineCustomItem(new MrMushroomItem()
+            MrMushroomItem mushItem = new()
             {
                 fieldName = nameof(PlayerData.mrMushroomState),
                 name = Consts.MrMushroomLevelUp,
@@ -23,18 +19,24 @@ namespace RandoPlus.MrMushroom
                     preview = new BoxedString("Mr Mushroom Level Up"),
                     name = new MrMushroomString(),
                 }
-            });
+            };
+            SupplementalMetadataTag itemMetadata = mushItem.AddTag<SupplementalMetadataTag>();
+            itemMetadata.PoolGroup = Consts.LoreTabletPoolGroup;
+            Finder.DefineCustomItem(mushItem);
 
             void DefineLocation(string name, string scene, string objectName, int level)
             {
-                Finder.DefineCustomLocation(new MrMushroomLocation()
+                MrMushroomLocation mushLocation = new()
                 {
                     name = name,
                     objectName = objectName,
                     mushroomState = level,
                     flingType = FlingType.Everywhere,
                     sceneName = scene,
-                });
+                };
+                SupplementalMetadataTag locationMetadata = mushLocation.AddTag<SupplementalMetadataTag>();
+                locationMetadata.PoolGroup = Consts.LoreTabletPoolGroup;
+                Finder.DefineCustomLocation(mushLocation);
             }
 
             DefineLocation(Consts.MrMushroomFungalWastes, SceneNames.Fungus2_18, "Mr Mushroom NPC", 1);

--- a/RandoPlus/RemoveUsefulItems/Items/ItemDefinition.cs
+++ b/RandoPlus/RemoveUsefulItems/Items/ItemDefinition.cs
@@ -1,4 +1,7 @@
-﻿using ItemChanger;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using ItemChanger;
 using ItemChanger.Items;
 using ItemChanger.UIDefs;
 

--- a/RandoPlus/RemoveUsefulItems/Items/ItemDefinition.cs
+++ b/RandoPlus/RemoveUsefulItems/Items/ItemDefinition.cs
@@ -6,6 +6,12 @@ namespace RandoPlus.RemoveUsefulItems.Items
 {
     public static class ItemDefinition
     {
+        private static void AddSkillMetadata(AbstractItem item)
+        {
+            SupplementalMetadataTag metadataTag = item.AddTag<SupplementalMetadataTag>();
+            metadataTag.PoolGroup = Consts.SkillsPoolGroup;
+        }
+
         public static void DefineItems()
         {
             UIDef lanternUIdef = Finder.GetItem(ItemNames.Lumafly_Lantern).UIDef.Clone();
@@ -16,6 +22,7 @@ namespace RandoPlus.RemoveUsefulItems.Items
                 moduleName = "RandoPlus.RemoveUsefulItems.Items.NoLanternModule, RandoPlus",
                 UIDef = lanternUIdef
             };
+            AddSkillMetadata(noLantern);
             Finder.DefineCustomItem(noLantern);
 
             BigUIDef tearUIdef = Finder.GetItem(ItemNames.Ismas_Tear).UIDef.Clone() as BigUIDef;
@@ -28,6 +35,7 @@ namespace RandoPlus.RemoveUsefulItems.Items
                 moduleName = "RandoPlus.RemoveUsefulItems.Items.NoTearModule, RandoPlus",
                 UIDef = tearUIdef
             };
+            AddSkillMetadata(noTear);
             Finder.DefineCustomItem(noTear);
 
             BigUIDef swimUIdef = Finder.GetItem(ItemNames.Swim).UIDef.Clone() as BigUIDef;
@@ -41,6 +49,7 @@ namespace RandoPlus.RemoveUsefulItems.Items
                 moduleName = "RandoPlus.RemoveUsefulItems.Items.NoSwimModule, RandoPlus",
                 UIDef = swimUIdef
             };
+            AddSkillMetadata(noSwim);
             Finder.DefineCustomItem(noSwim);
         }
     }

--- a/RandoPlus/SupplementalMetadataTag.cs
+++ b/RandoPlus/SupplementalMetadataTag.cs
@@ -1,0 +1,33 @@
+﻿using ItemChanger;
+using ItemChanger.Tags;
+
+namespace RandoPlus
+{
+    /// <summary>
+    /// Interop tag implementation for CMI pool groups
+    /// </summary>
+    /// <remarks>
+    /// This is not strictly needed, but it's much more convenient than defining an InteropTag each time with a message and
+    /// adding the poolgroup as a dict property. Additional properties (if needed in the future) can be added in a similar way
+    /// </remarks>
+    public class SupplementalMetadataTag : Tag, IInteropTag
+    {
+        private const string CmiPoolGroupProperty = "PoolGroup";
+
+        public string Message => "RandoSupplementalMetadata";
+
+        public string PoolGroup { get; set; }
+
+        public bool TryGetProperty<T>(string propertyName, out T value)
+        {
+            if (propertyName == CmiPoolGroupProperty && PoolGroup is T group)
+            {
+                value = group;
+                return true;
+            }
+
+            value = default;
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Quick note on group choice - I've put Mr. Mushroom in lore tablet group; I could see adding a custom group if you'd prefer. I'd consider this a medium-sized item group so it could go either way (for example there are more of these than journal entries which get their own group).