### PR TITLE
Added listen term for lore rando

### DIFF
--- a/RandoPlus/NailUpgrades/LogicAdder.cs
+++ b/RandoPlus/NailUpgrades/LogicAdder.cs
@@ -10,6 +10,7 @@ namespace RandoPlus.NailUpgrades
     class LogicAdder
     {
         private const string PALEORE = "PALEORE";
+        private const string LISTEN = "(LISTEN ? ANY)";
 
         public static void Hook()
         {
@@ -37,9 +38,9 @@ namespace RandoPlus.NailUpgrades
             if (!RandoPlus.GS.Any) return;
 
             lmb.AddLogicDef(new RawLogicDef(Consts.NailsmithLocationPrefix + "1", $"{SceneNames.Room_nailsmith}[left1]"));
-            lmb.AddLogicDef(new RawLogicDef(Consts.NailsmithLocationPrefix + "2", $"{SceneNames.Room_nailsmith}[left1] + {PALEORE} > 0"));
-            lmb.AddLogicDef(new RawLogicDef(Consts.NailsmithLocationPrefix + "3", $"{SceneNames.Room_nailsmith}[left1] + {PALEORE} > 2"));
-            lmb.AddLogicDef(new RawLogicDef(Consts.NailsmithLocationPrefix + "4", $"{SceneNames.Room_nailsmith}[left1] + {PALEORE} > 5"));
+            lmb.AddLogicDef(new RawLogicDef(Consts.NailsmithLocationPrefix + "2", $"{SceneNames.Room_nailsmith}[left1] + {PALEORE} > 0 + {LISTEN}"));
+            lmb.AddLogicDef(new RawLogicDef(Consts.NailsmithLocationPrefix + "3", $"{SceneNames.Room_nailsmith}[left1] + {PALEORE} > 2 + {LISTEN}"));
+            lmb.AddLogicDef(new RawLogicDef(Consts.NailsmithLocationPrefix + "4", $"{SceneNames.Room_nailsmith}[left1] + {PALEORE} > 5 + {LISTEN}"));
         }
 
         private static void DefineTermsAndItems(GenerationSettings gs, LogicManagerBuilder lmb)

--- a/RandoPlus/NailUpgrades/LogicAdder.cs
+++ b/RandoPlus/NailUpgrades/LogicAdder.cs
@@ -37,10 +37,10 @@ namespace RandoPlus.NailUpgrades
         {
             if (!RandoPlus.GS.Any) return;
 
-            lmb.AddLogicDef(new RawLogicDef(Consts.NailsmithLocationPrefix + "1", $"{SceneNames.Room_nailsmith}[left1]"));
-            lmb.AddLogicDef(new RawLogicDef(Consts.NailsmithLocationPrefix + "2", $"{SceneNames.Room_nailsmith}[left1] + {PALEORE} > 0 + {LISTEN}"));
-            lmb.AddLogicDef(new RawLogicDef(Consts.NailsmithLocationPrefix + "3", $"{SceneNames.Room_nailsmith}[left1] + {PALEORE} > 2 + {LISTEN}"));
-            lmb.AddLogicDef(new RawLogicDef(Consts.NailsmithLocationPrefix + "4", $"{SceneNames.Room_nailsmith}[left1] + {PALEORE} > 5 + {LISTEN}"));
+            lmb.AddLogicDef(new RawLogicDef(Consts.NailsmithLocationPrefix + "1", $"{SceneNames.Room_nailsmith}[left1] + {LISTEN}"));
+            lmb.AddLogicDef(new RawLogicDef(Consts.NailsmithLocationPrefix + "2", $"{SceneNames.Room_nailsmith}[left1] + {LISTEN} + {PALEORE} > 0"));
+            lmb.AddLogicDef(new RawLogicDef(Consts.NailsmithLocationPrefix + "3", $"{SceneNames.Room_nailsmith}[left1] + {LISTEN} + {PALEORE} > 2"));
+            lmb.AddLogicDef(new RawLogicDef(Consts.NailsmithLocationPrefix + "4", $"{SceneNames.Room_nailsmith}[left1] + {LISTEN} + {PALEORE} > 5"));
         }
 
         private static void DefineTermsAndItems(GenerationSettings gs, LogicManagerBuilder lmb)

--- a/RandoPlus/NailUpgrades/LogicAdder.cs
+++ b/RandoPlus/NailUpgrades/LogicAdder.cs
@@ -10,7 +10,7 @@ namespace RandoPlus.NailUpgrades
     class LogicAdder
     {
         private const string PALEORE = "PALEORE";
-        private const string LISTEN = "(LISTEN ? ANY)";
+        private const string LISTEN = "(LISTEN ? TRUE)";
 
         public static void Hook()
         {

--- a/RandoPlus/Resources/MrMushroom/logic.json
+++ b/RandoPlus/Resources/MrMushroom/logic.json
@@ -1,30 +1,30 @@
 ﻿[
     {
         "name": "Mr_Mushroom-Fungal_Wastes",
-        "logic": "Fungus2_18[top1] + Spore_Shroom + (MRMUSHROOMFOUND>0 | DREAMER3) + (LISTEN ? ANY)"
+        "logic": "Fungus2_18[top1] + Spore_Shroom + (MRMUSHROOMFOUND>0 | DREAMER3) + (LISTEN ? TRUE)"
     },
     {
         "name": "Mr_Mushroom-Kingdom's_Edge",
-        "logic": "(Deepnest_East_01[bot1] + (RIGHTCLAW | WINGS) | Deepnest_East_01[top1] | Deepnest_East_01[right1]) + Spore_Shroom + (MRMUSHROOMFOUND>1 | MRMUSHROOMFOUND>0 + DREAMER3) + (LISTEN ? ANY)"
+        "logic": "(Deepnest_East_01[bot1] + (RIGHTCLAW | WINGS) | Deepnest_East_01[top1] | Deepnest_East_01[right1]) + Spore_Shroom + (MRMUSHROOMFOUND>1 | MRMUSHROOMFOUND>0 + DREAMER3) + (LISTEN ? TRUE)"
     },
     {
         "name": "Mr_Mushroom-Deepnest",
-        "logic": "Deepnest_40[right1] + Spore_Shroom + (MRMUSHROOMFOUND>2 | MRMUSHROOMFOUND>1 + DREAMER3) + (LISTEN ? ANY)"
+        "logic": "Deepnest_40[right1] + Spore_Shroom + (MRMUSHROOMFOUND>2 | MRMUSHROOMFOUND>1 + DREAMER3) + (LISTEN ? TRUE)"
     },
     {
         "name": "Mr_Mushroom-Howling_Cliffs",
-        "logic": "Room_nailmaster[left1] + Spore_Shroom + (MRMUSHROOMFOUND>3 | MRMUSHROOMFOUND>2 + DREAMER3) + (LISTEN ? ANY)"
+        "logic": "Room_nailmaster[left1] + Spore_Shroom + (MRMUSHROOMFOUND>3 | MRMUSHROOMFOUND>2 + DREAMER3) + (LISTEN ? TRUE)"
     },
     {
         "name": "Mr_Mushroom-Ancient_Basin",
-        "logic": "Abyss_21[right1] + Spore_Shroom + (MRMUSHROOMFOUND>4 | MRMUSHROOMFOUND>3 + DREAMER3) + (LISTEN ? ANY)"
+        "logic": "Abyss_21[right1] + Spore_Shroom + (MRMUSHROOMFOUND>4 | MRMUSHROOMFOUND>3 + DREAMER3) + (LISTEN ? TRUE)"
     },
     {
         "name": "Mr_Mushroom-Fog_Canyon",
-        "logic": "Fungus3_44[bot1] + Spore_Shroom + (MRMUSHROOMFOUND>5 | MRMUSHROOMFOUND>4 + DREAMER3) + (LISTEN ? ANY)"
+        "logic": "Fungus3_44[bot1] + Spore_Shroom + (MRMUSHROOMFOUND>5 | MRMUSHROOMFOUND>4 + DREAMER3) + (LISTEN ? TRUE)"
     },
     {
         "name": "Mr_Mushroom-King's_Pass",
-        "logic": "Tutorial_01 + Spore_Shroom + (MRMUSHROOMFOUND>6 | MRMUSHROOMFOUND>5 + DREAMER3) + (LISTEN ? ANY)"
+        "logic": "Tutorial_01 + Spore_Shroom + (MRMUSHROOMFOUND>6 | MRMUSHROOMFOUND>5 + DREAMER3) + (LISTEN ? TRUE)"
     }
 ]

--- a/RandoPlus/Resources/MrMushroom/logic.json
+++ b/RandoPlus/Resources/MrMushroom/logic.json
@@ -1,30 +1,30 @@
 ﻿[
     {
         "name": "Mr_Mushroom-Fungal_Wastes",
-        "logic": "Fungus2_18[top1] + Spore_Shroom + (MRMUSHROOMFOUND>0 | DREAMER3)"
+        "logic": "Fungus2_18[top1] + Spore_Shroom + (MRMUSHROOMFOUND>0 | DREAMER3) + (LISTEN ? ANY)"
     },
     {
         "name": "Mr_Mushroom-Kingdom's_Edge",
-        "logic": "(Deepnest_East_01[bot1] + (RIGHTCLAW | WINGS) | Deepnest_East_01[top1] | Deepnest_East_01[right1]) + Spore_Shroom + (MRMUSHROOMFOUND>1 | MRMUSHROOMFOUND>0 + DREAMER3)"
+        "logic": "(Deepnest_East_01[bot1] + (RIGHTCLAW | WINGS) | Deepnest_East_01[top1] | Deepnest_East_01[right1]) + Spore_Shroom + (MRMUSHROOMFOUND>1 | MRMUSHROOMFOUND>0 + DREAMER3) + (LISTEN ? ANY)"
     },
     {
         "name": "Mr_Mushroom-Deepnest",
-        "logic": "Deepnest_40[right1] + Spore_Shroom + (MRMUSHROOMFOUND>2 | MRMUSHROOMFOUND>1 + DREAMER3)"
+        "logic": "Deepnest_40[right1] + Spore_Shroom + (MRMUSHROOMFOUND>2 | MRMUSHROOMFOUND>1 + DREAMER3) + (LISTEN ? ANY)"
     },
     {
         "name": "Mr_Mushroom-Howling_Cliffs",
-        "logic": "Room_nailmaster[left1] + Spore_Shroom + (MRMUSHROOMFOUND>3 | MRMUSHROOMFOUND>2 + DREAMER3)"
+        "logic": "Room_nailmaster[left1] + Spore_Shroom + (MRMUSHROOMFOUND>3 | MRMUSHROOMFOUND>2 + DREAMER3) + (LISTEN ? ANY)"
     },
     {
         "name": "Mr_Mushroom-Ancient_Basin",
-        "logic": "Abyss_21[right1] + Spore_Shroom + (MRMUSHROOMFOUND>4 | MRMUSHROOMFOUND>3 + DREAMER3)"
+        "logic": "Abyss_21[right1] + Spore_Shroom + (MRMUSHROOMFOUND>4 | MRMUSHROOMFOUND>3 + DREAMER3) + (LISTEN ? ANY)"
     },
     {
         "name": "Mr_Mushroom-Fog_Canyon",
-        "logic": "Fungus3_44[bot1] + Spore_Shroom + (MRMUSHROOMFOUND>5 | MRMUSHROOMFOUND>4 + DREAMER3)"
+        "logic": "Fungus3_44[bot1] + Spore_Shroom + (MRMUSHROOMFOUND>5 | MRMUSHROOMFOUND>4 + DREAMER3) + (LISTEN ? ANY)"
     },
     {
         "name": "Mr_Mushroom-King's_Pass",
-        "logic": "Tutorial_01 + Spore_Shroom + (MRMUSHROOMFOUND>6 | MRMUSHROOMFOUND>5 + DREAMER3)"
+        "logic": "Tutorial_01 + Spore_Shroom + (MRMUSHROOMFOUND>6 | MRMUSHROOMFOUND>5 + DREAMER3) + (LISTEN ? ANY)"
     }
 ]


### PR DESCRIPTION
Since cursed listening does affect nailsmith and Mr. Mushroom, I've added the optional term to their clauses.

Before, LoreMaster did take care of that, but I feel like modifying it here with the new logic states is much cleaner than me searching through all logic defs.^^

Regarding the ghost essence, lore rando does just spawn a shiny if the item can be obtained but the ghost is killed, instead of making the ghost unkillable until then. So no modifications are necessary.