### PR TITLE
Added DefineRefs check for Nail Upgrades definition if disabled.

### DIFF
--- a/RandoPlus/NailUpgrades/LogicAdder.cs
+++ b/RandoPlus/NailUpgrades/LogicAdder.cs
@@ -35,7 +35,7 @@ namespace RandoPlus.NailUpgrades
 
         private static void ApplyLogic(GenerationSettings gs, LogicManagerBuilder lmb)
         {
-            if (!RandoPlus.GS.Any) return;
+            if (!RandoPlus.GS.NailUpgrades || !RandoPlus.GS.DefineRefs) return;
 
             lmb.AddLogicDef(new RawLogicDef(Consts.NailsmithLocationPrefix + "1", $"{SceneNames.Room_nailsmith}[left1] + {LISTEN}"));
             lmb.AddLogicDef(new RawLogicDef(Consts.NailsmithLocationPrefix + "2", $"{SceneNames.Room_nailsmith}[left1] + {LISTEN} + {PALEORE} > 0"));
@@ -45,7 +45,7 @@ namespace RandoPlus.NailUpgrades
 
         private static void DefineTermsAndItems(GenerationSettings gs, LogicManagerBuilder lmb)
         {
-            if (!RandoPlus.GS.Any) return;
+            if (!RandoPlus.GS.NailUpgrades || !RandoPlus.GS.DefineRefs) return;
 
             Term nailupTerm = lmb.GetOrAddTerm("NAILUPGRADE");
             lmb.AddItem(new SingleItem(Consts.NailUpgrade, new TermValue(nailupTerm, 1)));

--- a/RandoPlus/NailUpgrades/LogicAdder.cs
+++ b/RandoPlus/NailUpgrades/LogicAdder.cs
@@ -35,7 +35,7 @@ namespace RandoPlus.NailUpgrades
 
         private static void ApplyLogic(GenerationSettings gs, LogicManagerBuilder lmb)
         {
-            if (!RandoPlus.GS.NailUpgrades || !RandoPlus.GS.DefineRefs) return;
+            if (!RandoPlus.GS.NailUpgrades && !RandoPlus.GS.DefineRefs) return;
 
             lmb.AddLogicDef(new RawLogicDef(Consts.NailsmithLocationPrefix + "1", $"{SceneNames.Room_nailsmith}[left1] + {LISTEN}"));
             lmb.AddLogicDef(new RawLogicDef(Consts.NailsmithLocationPrefix + "2", $"{SceneNames.Room_nailsmith}[left1] + {LISTEN} + {PALEORE} > 0"));
@@ -45,7 +45,7 @@ namespace RandoPlus.NailUpgrades
 
         private static void DefineTermsAndItems(GenerationSettings gs, LogicManagerBuilder lmb)
         {
-            if (!RandoPlus.GS.NailUpgrades || !RandoPlus.GS.DefineRefs) return;
+            if (!RandoPlus.GS.NailUpgrades && !RandoPlus.GS.DefineRefs) return;
 
             Term nailupTerm = lmb.GetOrAddTerm("NAILUPGRADE");
             lmb.AddItem(new SingleItem(Consts.NailUpgrade, new TermValue(nailupTerm, 1)));


### PR DESCRIPTION
If both settings are disabled, the process won't run now. If DefineRefs is on, they're defined and placed vanilla. If Nail Upgrades are on, it behaves normally.